### PR TITLE
Remove spaces from as patterns

### DIFF
--- a/src/Data/BEncode/BDict.hs
+++ b/src/Data/BEncode/BDict.hs
@@ -131,7 +131,7 @@ lookup x = go
 union :: BDictMap a -> BDictMap a -> BDictMap a
 union Nil xs  = xs
 union xs  Nil = xs
-union bd @ (Cons k v xs) bd' @ (Cons k' v' xs')
+union bd@(Cons k v xs) bd'@(Cons k' v' xs')
   |   k < k'  = Cons k  v  (union xs bd')
   | otherwise = Cons k' v' (union bd xs')
 


### PR DESCRIPTION
GHC 9.0.1 complains about spaces around as-patterns.
```
src/Data/BEncode/BDict.hs:134:10: error:
    Found a binding for the ‘@’ operator in a pattern position.
    Perhaps you meant an as-pattern, which must not be surrounded by whitespace
    In a function binding for the ‘@’ operator.
    Perhaps you meant an as-pattern, which must not be surrounded by whitespace
    |
134 | union bd @ (Cons k v xs) bd' @ (Cons k' v' xs')
    |          ^
```