### PR TITLE
ghc-9.6 compatible Alternative instance for Get

### DIFF
--- a/src/Data/BEncode.hs
+++ b/src/Data/BEncode.hs
@@ -668,7 +668,7 @@ endDict = Nil
 --  \"length\" '<' \"md5sum\" '<' \"path\" '<' \"tags\"
 --
 newtype Get a = Get { runGet :: StateT BDict Result a }
-  deriving (Functor, Applicative, Alternative)
+  deriving (Functor, Applicative)
 
 -- | 'fail' is catchable from pure code.
 instance Monad Get where
@@ -689,6 +689,11 @@ instance MonadFail Get where
   fail msg = Get (lift (Left msg))
   {-# INLINE fail #-}
 #endif
+
+-- | NOTE: @'Control.Applicative.empty' = 'fail' ""@.
+instance Alternative Get where
+  empty = fail ""
+  Get (StateT m) <|> Get (StateT n) = Get $ StateT $ \s -> m s <> n s
 
 -- | Run action, but return without consuming and key\/value pair.
 -- Fails if the action fails.

--- a/tests/properties.hs
+++ b/tests/properties.hs
@@ -66,6 +66,9 @@ data T a = T
 prop_bencodable :: Eq a => BEncode a => T a -> a -> Bool
 prop_bencodable _ x = decode (BL.toStrict (encode x)) == Right x
 
+emptyGet :: Get Int
+emptyGet = A.empty
+
 main :: IO ()
 main = hspec $ do
   describe "BValue" $ do
@@ -84,3 +87,9 @@ main = hspec $ do
       fromDict (fail "fatal error" :: Get Int) (BDict BE.Nil)
            `shouldBe`
        Left "fatal error"
+    it "empty alternative is empty string" $ do
+      fromDict emptyGet (BDict BE.Nil) `shouldBe` Left ""
+    it "alternative composition" $ do
+      fromDict (emptyGet <|> emptyGet) (BDict BE.Nil) `shouldBe` Left ""
+      fromDict (pure 5 <|> emptyGet) (BDict BE.Nil) `shouldBe` Right 5
+      fromDict (emptyGet <|> pure 3) (BDict BE.Nil) `shouldBe` Right 3


### PR DESCRIPTION
Hello, this is an attempt at fixing #4. I am a beginner at Haskell, so please let me know if I am misunderstanding something.

The first commit builds and passes tests on ghc-9.4 and shows what the desired (?) behavior of `Alternative Get` is. The second commit then explicitly implements the legacy behavior.